### PR TITLE
Serve frontend & backend separately in local dev environment

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -18,4 +18,22 @@
 }
 ```
 
-3. Happy coding, run `dotnet run` to serve both frontend & backend
+3. Run backend and frontend separately:
+
+```bash
+# terminal 1 (backend)
+cd MathAPI
+dotnet run
+
+# terminal 2 (frontend)
+cd web-client
+cp .env.development.example .env.development.local
+npm install
+npm run dev
+```
+
+4. If backend is not running at `http://localhost:5204`, update `web-client/.env.development.local`:
+
+```env
+VITE_BACKEND_URL=http://localhost:5000
+```

--- a/MathAPI/Program.cs
+++ b/MathAPI/Program.cs
@@ -4,7 +4,6 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
 using System.Text;
 using System.Text.Json.Serialization;
-using Microsoft.Extensions.FileProviders;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -52,24 +51,6 @@ if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();
     app.UseSwaggerUI();
-    // also serve frontend at the same address in development
-    var frontendDist = Path.Combine(builder.Environment.ContentRootPath, "../web-client/dist");
-    app.Use(async (ctx, next) =>
-    {
-        // If the path has no extension (e.g. /, /dashboard, /login)
-        // rewrite it to /index.html so static file middleware can serve it.
-        if (!Path.HasExtension(ctx.Request.Path.Value))
-        {
-            ctx.Request.Path = "/index.html";
-        }
-
-        await next();
-    });
-    app.UseStaticFiles(new StaticFileOptions
-    {
-        FileProvider = new PhysicalFileProvider(frontendDist),
-        RequestPath = ""
-    });
 }
 
 app.UseAuthentication();

--- a/web-client/.env.development.example
+++ b/web-client/.env.development.example
@@ -1,0 +1,1 @@
+VITE_BACKEND_URL=http://localhost:5204

--- a/web-client/src/utils/api.js
+++ b/web-client/src/utils/api.js
@@ -2,7 +2,8 @@ import axios from 'axios';
 
 // 创建 axios 实例
 const api = axios.create({
-    baseURL: '/api', // Nginx 会把这个转发给后端
+    // In dev, Vite proxies /api to VITE_BACKEND_URL; in prod this can be handled by ingress/Nginx.
+    baseURL: '/api',
     headers: {
         'Content-Type': 'application/json'
     }

--- a/web-client/vite.config.js
+++ b/web-client/vite.config.js
@@ -4,4 +4,12 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': {
+        target: process.env.VITE_BACKEND_URL || 'http://localhost:5204',
+        changeOrigin: true,
+      },
+    },
+  },
 })


### PR DESCRIPTION
Kestrel-served frontend does not support hot-reloading for frontend, which is somewhat of a pain for developers. This PR removes that local static file serving in backend, and added environment files for the frontend to be served separately.