### PR TITLE
Remove hard coded secret values and inject them via environment instead

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-ef": {
+      "version": "10.0.1",
+      "commands": [
+        "dotnet-ef"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/.github/workflows/devops.yml
+++ b/.github/workflows/devops.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Restore dependencies
       run: |
         dotnet restore
-        dotnet tool install --global dotnet-ef --version 10.0
+        dotnet tool install --global dotnet-ef
     - name: Build
       run: dotnet publish
     - name: Generate Migration Script

--- a/.github/workflows/devops.yml
+++ b/.github/workflows/devops.yml
@@ -13,23 +13,23 @@ jobs:
     runs-on: [self-hosted]
 
     container:
-      image: mcr.microsoft.com/dotnet/sdk:10.0
+      image: mcr.microsoft.com/dotnet/sdk:10.0.103
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 10.0.x
+        dotnet-version: 10.0.103
     - name: Restore dependencies
       run: |
         dotnet restore
-        dotnet tool install --global dotnet-ef
+        dotnet tool restore
     - name: Build
       run: dotnet publish
     - name: Generate Migration Script
       run: |
-        export PATH="$PATH:/github/home/.dotnet/tools"
-        dotnet ef --project MathAPI migrations script --idempotent --output MathAPI/bin/Release/net8.0/publish/migration.sql
+        dotnet tool run dotnet-ef --version
+        dotnet tool run dotnet-ef --project MathAPI/MathAPI.csproj --startup-project MathAPI/MathAPI.csproj migrations script --idempotent --output MathAPI/bin/Release/net10.0/publish/migration.sql
     - name: publish backend
       uses: actions/upload-artifact@v4
       with:

--- a/MathAPI/Controllers/AuthController.cs
+++ b/MathAPI/Controllers/AuthController.cs
@@ -4,8 +4,11 @@ using MathAPI.Models;
 using Microsoft.IdentityModel.Tokens;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
+using System.Security.Cryptography;
 using System.Text;
 using BCrypt.Net;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Configuration;
 
 namespace MathAPI.Controllers
 {
@@ -14,27 +17,55 @@ namespace MathAPI.Controllers
     public class AuthController : ControllerBase
     {
         private readonly MathContext _context;
-        private const string Secret = "ThisIsASecretKeyForMakiMathPlatform2025!DoNotShare";
+        private readonly InitAdminOptions _initAdminOptions;
+        private readonly ILogger<AuthController> _logger;
+        private readonly string _jwtSecret;
 
-        public AuthController(MathContext context)
+        public AuthController(
+            MathContext context,
+            InitAdminOptions initAdminOptions,
+            ILogger<AuthController> logger,
+            IConfiguration configuration)
         {
             _context = context;
+            _initAdminOptions = initAdminOptions;
+            _logger = logger;
+            _jwtSecret = configuration["Jwt:Secret"] ?? configuration["JWT_SECRET"]
+                ?? throw new InvalidOperationException("JWT secret is not configured. Set Jwt:Secret or JWT_SECRET.");
         }
 
         // 超级管理员初始化接口（只能在数据库为空时调用一次）
         [HttpPost("init-admin")]
-        public IActionResult InitAdmin()
+        public IActionResult InitAdmin([FromHeader(Name = "X-Init-Token")] string? initToken)
         {
+            var expectedToken = _initAdminOptions.Token;
+            if (string.IsNullOrWhiteSpace(expectedToken))
+            {
+                _logger.LogError("Init-admin endpoint invoked but no InitAdminToken is configured.");
+                return StatusCode(500, "Init admin token is not configured.");
+            }
+
+            if (string.IsNullOrWhiteSpace(initToken) || initToken != expectedToken)
+            {
+                _logger.LogWarning("Rejected init-admin attempt from {RemoteIp} due to invalid token.", HttpContext.Connection.RemoteIpAddress);
+                return Unauthorized("Invalid init token.");
+            }
+
             if (_context.Users.Any()) return BadRequest("Users already exist.");
+
+            var adminPassword = Convert.ToBase64String(RandomNumberGenerator.GetBytes(18));
             
             var admin = new User 
             { 
                 Username = "admin", 
-                PasswordHash = BCrypt.Net.BCrypt.HashPassword("admin123"), // 默认密码
+                PasswordHash = BCrypt.Net.BCrypt.HashPassword(adminPassword),
                 Role = UserRole.Admin 
             };
             _context.Users.Add(admin);
             _context.SaveChanges();
+
+            _logger.LogWarning("Initial admin created. Username: admin, Password: {AdminPassword}", adminPassword);
+
             return Ok("Admin created.");
         }
 
@@ -47,7 +78,7 @@ namespace MathAPI.Controllers
 
             // 生成 JWT Token
             var tokenHandler = new JwtSecurityTokenHandler();
-            var key = Encoding.ASCII.GetBytes(Secret);
+            var key = Encoding.ASCII.GetBytes(_jwtSecret);
             var tokenDescriptor = new SecurityTokenDescriptor
             {
                 Subject = new ClaimsIdentity(new[] 

--- a/MathAPI/Data/MathContextFactory.cs
+++ b/MathAPI/Data/MathContextFactory.cs
@@ -1,0 +1,34 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.Extensions.Configuration;
+
+namespace MathAPI.Data;
+
+/// <summary>
+/// Design-time DbContext factory for EF Core tools.
+/// This avoids requiring the full web host (and JWT config) when running commands like:
+/// dotnet ef migrations list/script
+/// </summary>
+public sealed class MathContextFactory : IDesignTimeDbContextFactory<MathContext>
+{
+    public MathContext CreateDbContext(string[] args)
+    {
+        var configuration = new ConfigurationBuilder()
+            .SetBasePath(Directory.GetCurrentDirectory())
+            .AddJsonFile("appsettings.json", optional: true)
+            .AddJsonFile("MathAPI/appsettings.json", optional: true)
+            .AddEnvironmentVariables()
+            .Build();
+
+        var connectionString = configuration.GetConnectionString("DefaultConnection")
+            ?? configuration["ConnectionStrings:DefaultConnection"]
+            // fallback so EF tooling that does not need a live DB (e.g. migrations list/script)
+            // can still construct the context when no connection string is configured locally.
+            ?? "Host=localhost;Database=mathapi_design;Username=postgres;Password=postgres";
+
+        var optionsBuilder = new DbContextOptionsBuilder<MathContext>();
+        optionsBuilder.UseNpgsql(connectionString);
+
+        return new MathContext(optionsBuilder.Options);
+    }
+}

--- a/MathAPI/MathAPI.csproj
+++ b/MathAPI/MathAPI.csproj
@@ -11,10 +11,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.3">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.3" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.4" />
   </ItemGroup>

--- a/MathAPI/Models/InitAdminOptions.cs
+++ b/MathAPI/Models/InitAdminOptions.cs
@@ -1,0 +1,11 @@
+namespace MathAPI.Models;
+
+public sealed class InitAdminOptions
+{
+    public string Token { get; }
+
+    public InitAdminOptions(string token)
+    {
+        Token = token;
+    }
+}

--- a/MathAPI/Program.cs
+++ b/MathAPI/Program.cs
@@ -5,6 +5,8 @@ using Microsoft.IdentityModel.Tokens;
 using System.Text;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.FileProviders;
+using System.Security.Cryptography;
+using MathAPI.Models;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -14,7 +16,8 @@ builder.Services.AddDbContext<MathContext>(options =>
     options.UseNpgsql(connectionString));
 
 // 2. 配置 JWT 鉴权
-var jwtKey = "ThisIsASecretKeyForMakiMathPlatform2025!DoNotShare";
+var jwtKey = builder.Configuration["Jwt:Secret"] ?? builder.Configuration["JWT_SECRET"]
+    ?? throw new InvalidOperationException("JWT secret is not configured. Set Jwt:Secret or JWT_SECRET.");
 var key = Encoding.ASCII.GetBytes(jwtKey);
 
 builder.Services.AddAuthentication(x =>
@@ -46,7 +49,13 @@ builder.Services.AddControllers()
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
+var initAdminToken = Convert.ToHexString(RandomNumberGenerator.GetBytes(32));
+builder.Services.AddSingleton(new InitAdminOptions(initAdminToken));
+
 var app = builder.Build();
+
+var startupLogger = app.Services.GetRequiredService<ILoggerFactory>().CreateLogger("Startup");
+startupLogger.LogWarning("Init admin bootstrap token (header: X-Init-Token): {InitAdminToken}", initAdminToken);
 
 if (app.Environment.IsDevelopment())
 {

--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
-    {
-      "sdk": {
-        "version": "8.0"
-      }
-    }
+{
+  "sdk": {
+    "version": "10.0.103",
+    "rollForward": "disable"
+  }
+}


### PR DESCRIPTION
This PR removes hard coded secrets, instead it opts for environment injected secret for the JWT key.

Admin initialization endpoint is updated to print a random token in the console.

Default admin password is also made random generated, and printed to console.